### PR TITLE
For v1.0.0-RC3 - boot, startup defaults, defer report config isues.

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,38 +1,5 @@
 
-TODO:   original splice issues, https://github.com/sjl/splice.vim
-
-        Ability to quickly switch both panels in 'compare' mode
-                https://github.com/sjl/splice.vim/issues/32
-            Commented: Maybe user defined shortcuts? Like `bind_user`.
-
-        can't open submodule dir
-                https://github.com/sjl/splice.vim/issues/25
-            fugitive interactions?
-
-        Problem when file path contains dot
-                https://github.com/sjl/splice.vim/issues/26
-            python traceback
-
-        Splice inserts carriage returns (^M) to every line in the final
-        version when merging text file
-                https://github.com/sjl/splice.vim/issues/24
-            Commented: How to reproduce?
-
-        Splice fails to load if any input file is missing
-                https://github.com/sjl/splice.vim/issues/23
-            Commented: What should happen? Difftool mode?
-
-        Splice closes immediatly on Windows
-                https://github.com/sjl/splice.vim/issues/20
-            Commented: still an issue?
-
-        Bug in changing files to compare
-                https://github.com/sjl/splice.vim/issues/10
-            Commented:
-            Hi @dwijnand , @Profpatsch, @vlmarek
-            Think that this issue and #16 and #32 all the same thing?
-
-        The rest of them are very old, assume they're dealt with.
+TODO:   Only use *highlight-default* for Splice default highlights.
 
 TODO:   Convert help to html. Use jVi tools?
 
@@ -87,6 +54,44 @@ TODO:   Use construct like: buffers.result.winnr (NOTE: the -1)
 
 TODO:   Understand scrollbind,syncbind,scrollopt
         'diff' mode, diff.txt
+
+===========  Issues from the original Splice  ===========
+
+https://github.com/sjl/splice.vim
+
+Ability to quickly switch both panels in 'compare' mode
+        https://github.com/sjl/splice.vim/issues/32
+    Commented: Maybe user defined shortcuts? Like `bind_user`.
+
+can't open submodule dir
+        https://github.com/sjl/splice.vim/issues/25
+    fugitive interactions?
+
+Problem when file path contains dot
+        https://github.com/sjl/splice.vim/issues/26
+    python traceback
+
+Splice inserts carriage returns (^M) to every line in the final
+version when merging text file
+        https://github.com/sjl/splice.vim/issues/24
+    Commented: How to reproduce?
+
+Splice fails to load if any input file is missing
+        https://github.com/sjl/splice.vim/issues/23
+    Commented: What should happen? Difftool mode?
+
+Splice closes immediatly on Windows
+        https://github.com/sjl/splice.vim/issues/20
+    Commented: still an issue?
+
+Bug in changing files to compare
+        https://github.com/sjl/splice.vim/issues/10
+    Commented:
+    Hi @dwijnand , @Profpatsch, @vlmarek
+    Think that this issue and #16 and #32 all the same thing?
+
+The rest of them are very old, assume they're dealt with.
+
 
 === Do the other premerge options work? keep-merge3, keep-mergediff
 

--- a/autoload/splice9dev/splice.vim
+++ b/autoload/splice9dev/splice.vim
@@ -98,11 +98,11 @@ export def SpliceInit9(settings_issues: list<string>)
     endif
     startup_error_msgs = null_list
 
-    # non-fatal, we have a go for lift-off
-    ReportConfigIssues(settings_issues)
-
     i_result.Init()
     i_search.Init()
+
+    # non-fatal, we have a go for lift-off
+    ReportConfigIssues(settings_issues)
 
     i_log.Log('Splice started.')
 enddef

--- a/autoload/splice9dev/splice_boot.vim
+++ b/autoload/splice9dev/splice_boot.vim
@@ -49,7 +49,7 @@ export def SpliceBoot()
         i_splice.SpliceInit9(settings_errors)
     catch
         failures->add(v:exception)
-        AddStack(v:throwpoint)
+        AddStack(i_log.throwpoint ?? v:throwpoint)
         SpliceBootError2()
     endtry
 enddef
@@ -93,9 +93,11 @@ def SpliceBootError2()
         Click popup or enter 'y'/'n' to abort the merge.
     END
     failures->extend(instrs)
-    for msg in failures
-        i_log.Log(msg, 'error')
-    endfor
+    if i_log.IsEnabled()
+        for msg in failures
+            i_log.Log(msg, 'error')
+        endfor
+    endif
     SpliceDidNotLoad()
 enddef
 

--- a/plugin/splice.vim
+++ b/plugin/splice.vim
@@ -39,7 +39,7 @@ endif
 vim9script
 
 # NOTE: The following is grabbed by shell to label the release zip
-export const splice9_string_version = "1.0.0-RC2-dev"
+export const splice9_string_version = "1.0.0-RC3-dev"
 
 # TODO: SHOULD THERE BE A SPLICE COMMAND IF VERSION PREVENTS RUNNING?
 


### PR DESCRIPTION
- During boot don't try to access logging if logging didn't init. 
- During startup handle a default highlight not available. 
- Don't report config issues until startup is fully complete.